### PR TITLE
Use Docker Compose profiles for unified build and test setup

### DIFF
--- a/.github/actions/tjbots-build-setup/action.yml
+++ b/.github/actions/tjbots-build-setup/action.yml
@@ -1,0 +1,17 @@
+name: TJBots Build Setup
+description: "setup Docker build environment with QEMU, Buildx, and GitHub Container Registry login"
+runs:
+  using: "composite"
+  steps:
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ github.token }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3

--- a/.github/actions/tjbots-python-setup/action.yml
+++ b/.github/actions/tjbots-python-setup/action.yml
@@ -1,5 +1,5 @@
-name: "tjbots-setup"
-description: "Reusable setup action for TJBots workflows: setup Python, install uv, cache playwright, install deps"
+name: TJBots Python Setup
+description: "setup Python, install uv, cache playwright, install deps"
 inputs:
   python-version:
     description: 'Python version to set up'

--- a/.github/workflows/tjbots-publish.yml
+++ b/.github/workflows/tjbots-publish.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/tjbots-publish.yml"
+      - ".github/actions/tjbots-*-setup/**"
       - "src/**"
       - "assets/**"
       - "build/**"
@@ -14,27 +15,16 @@ on:
 name: Publish TJBots
 
 jobs:
-  app-publish:
+  
+  build-publish:
     name: Publish TJBots image to GitHub Container Registry 
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: TJBots build setup
+        uses: ./.github/actions/tjbots-build-setup
 
       - name: Build and push application image
-        run: make docker-publish
-        env: 
-          PLATFORM: linux/amd64,linux/arm64
+        run: make docker-build-publish

--- a/.github/workflows/tjbots-test.yml
+++ b/.github/workflows/tjbots-test.yml
@@ -3,23 +3,40 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/tjbots-test.yml"
+      - ".github/actions/tjbots-*-setup/**"
       - "src/**"
-      - "tests/**"
+      - "assets/**"
+      - "build/**"
       - "pyproject.toml"
       - "uv.lock"
+      - "Makefile"
 
 name: Test TJBots
 
 jobs:
-  test:
-    name: Run tests with pytest
+
+  python-test:
+    name: Run python tests with pytest
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: TJBots setup
-        uses: ./.github/actions/tjbots-setup
+      - name: TJBots python setup
+        uses: ./.github/actions/tjbots-python-setup
 
       - name: Run tests
         run: make test
+
+  build-test: 
+    name: Run build test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: TJBots build setup
+        uses: ./.github/actions/tjbots-build-setup
+
+      - name: Run build test
+        run: make docker-build-test

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,18 +1,32 @@
 services:
   tjbots:
     container_name: ${DOCKER_NAME}
-    build: 
+    image: ${DOCKER_IMG}:${VERSION}
+    build: &build
       context: ..
       dockerfile: build/Dockerfile
-      labels:
-        org.opencontainers.image.source: ${REPO_URL}
-        org.opencontainers.image.licenses: ${LICENSE}
-      tags:
-        - ${DOCKER_IMG}:${VERSION}
-        - ${DOCKER_IMG}:latest
     volumes:
       - type: bind
         source: ${SECRETS_FILE}
         target: ${SECRETS_FILE}
     ports:
       - "8080:8080"
+  tjbots-release:
+    profiles: 
+      - release
+    build:
+      <<: *build
+      labels:
+        org.opencontainers.image.source: ${REPO_URL}
+        org.opencontainers.image.licenses: ${LICENSE}
+      tags:
+        - ${DOCKER_IMG}:${VERSION}
+        - ${DOCKER_IMG}:${LATEST-latest}
+      cache_from: 
+        - ${DOCKER_IMG}:${CACHE-cache}
+      cache_to: 
+        - ${DOCKER_IMG}:${CACHE-cache}
+      x-bake: 
+        platforms: 
+          - linux/amd64 
+          - linux/arm64

--- a/docs/journal/01-development/06-cicd.qmd
+++ b/docs/journal/01-development/06-cicd.qmd
@@ -6,3 +6,4 @@
 - First we want the docker-build target to be based on the compose file
 - Docker service profiles kind of work for situations where you need to activate/deactivate specific services for testing or deployment, but it does not unify the configuration for testing and deployment.
 - [Docker docs](https://docs.docker.com/build/bake/compose-file/) indicate you can use yaml anchors to separate the release target from the running target
+- We can use the `tjbots` service in docker compose for both building in dev and production because we can specify both the `build` and `image` arguments. 

--- a/docs/journal/01-development/06-cicd.qmd
+++ b/docs/journal/01-development/06-cicd.qmd
@@ -1,0 +1,8 @@
+# Continuous Integration / Deployment
+
+## Unifying docker compmose for testing and deployment 
+
+- Currently we have the `docker-compose.yml` file in `tests/` and an unused one in `build/`.
+- First we want the docker-build target to be based on the compose file
+- Docker service profiles kind of work for situations where you need to activate/deactivate specific services for testing or deployment, but it does not unify the configuration for testing and deployment.
+- [Docker docs](https://docs.docker.com/build/bake/compose-file/) indicate you can use yaml anchors to separate the release target from the running target


### PR DESCRIPTION
- Use the same docker compose file for testing, development, CI/CD, and publishing (build/docker-compose.yml)

Fixes #26